### PR TITLE
fix :: PLAIN JAR 파일 무시하도록 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN ./gradlew bootJar -x test --no-daemon --parallel --build-cache \
     -Dorg.gradle.parallel=true \
     -Dorg.gradle.jvmargs="-Xmx2g -XX:+UseParallelGC" && \
     mkdir -p extracted && \
-    java -Djarmode=layertools -jar build/libs/*[!-plain].jar extract --destination extracted
+    JAR_FILE=$(find build/libs -name "*.jar" ! -name "*-plain.jar") && \
+    java -Djarmode=layertools -jar "$JAR_FILE" extract --destination extracted
 
 FROM eclipse-temurin:17-jre AS optimizer
 WORKDIR /app


### PR DESCRIPTION
PLAIN JAR 파일을 무시하도록 설정했습니다. 제발 되면 좋겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 빌드 단계의 JAR 추출 방식을 더 신뢰성 있게 개선했습니다.
  * 단일 빌드 아티팩트를 정확히 식별하도록 변경하고, 경로 처리를 안전하게 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->