### PR TITLE
SpEL 빈 참조 방식 변경

### DIFF
--- a/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumRestTemplateConfig.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumRestTemplateConfig.kt
@@ -10,8 +10,7 @@ import org.springframework.web.client.RestTemplate
 @Configuration
 @EnableConfigurationProperties(
     DebeziumProperties::class,
-    DebeziumClientProperties::class,
-    DebeziumRetryProperties::class
+    DebeziumClientProperties::class
 )
 @ConditionalOnProperty(
     prefix = "debezium",

--- a/src/main/kotlin/dsm/pick2024/infrastructure/debezium/DebeziumConnectorService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/debezium/DebeziumConnectorService.kt
@@ -2,7 +2,6 @@ package dsm.pick2024.infrastructure.debezium
 
 import com.google.gson.Gson
 import dsm.pick2024.global.config.debezium.DebeziumProperties
-import dsm.pick2024.global.config.debezium.DebeziumRetryProperties
 import dsm.pick2024.infrastructure.debezium.exception.DebeziumConfigurationException
 import dsm.pick2024.infrastructure.debezium.exception.DebeziumConnectorException
 import dsm.pick2024.infrastructure.debezium.exception.DebeziumRetryableException


### PR DESCRIPTION
SpEL에서 DebeziumRetryProperties로 빈을 참조할 때 예상했던 이름과 달라 빈 참조에 실패하고 있었습니다
SpEL를 사용하지 않게 참조 방식을 변경했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기술 개선**
  * 재시도 설정이 애플리케이션 설정 파일의 프로퍼티(기본값 포함)로 직접 읽히도록 변경되어 구성과 튜닝이 더 간편해졌습니다(최대 시도, 초기 지연, 배수, 최대 지연 등).
  * 서비스 생성자가 단순화되어 별도의 재시도 설정 객체를 주입할 필요가 없어졌습니다.
  * 구성 바인딩에서 재시도 전용 프로퍼티 클래스가 제거되어 설정 관리가 정리되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->