### PR TITLE
feign client error decoder에 로깅 추가

### DIFF
--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/FeignClientErrorDecoder.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/FeignClientErrorDecoder.kt
@@ -12,13 +12,23 @@ import org.slf4j.LoggerFactory
 class FeignClientErrorDecoder : ErrorDecoder {
     private val log = LoggerFactory.getLogger(this::class.java)
     override fun decode(methodKey: String?, response: Response?): Exception {
-        response?.let { log.error("‼️error reason: ${response.reason()} error body: ${response.body()}") }
-        if (response!!.status() >= 400) {
-            when (response.status()) {
-                400 -> throw FeignBadRequestException
-                401 -> throw FeignUnAuthorizedException
-                403 -> throw FeignForbiddenException
-                else -> throw FeignServerError
+        response?.let {
+            response.body().asInputStream().use { stream ->
+                val body = stream.readBytes().toString(Charsets.UTF_8)
+                val truncatedBody = if (body.length > 1000) body.take(1000) + "... (truncated)" else body
+                log.error(
+                    "Feign error - method: $methodKey, status: ${response.status()}," +
+                        " reason: ${response.reason()}, body: $truncatedBody"
+                )
+            }
+
+            if (response.status() >= 400) {
+                when (response.status()) {
+                    400 -> throw FeignBadRequestException
+                    401 -> throw FeignUnAuthorizedException
+                    403 -> throw FeignForbiddenException
+                    else -> throw FeignServerError
+                }
             }
         }
         return FeignException.errorStatus(methodKey, response)


### PR DESCRIPTION
지금 같은 환경에서 로컬로는 fcm이 잘 되는데 stag, prod에서 403이 뜹니다..
근데 이 403 에러를 feign decoder가 잡아서 커스텀 에러로 던져서 에러 body를 볼 수가 없습니다 ㅜㅜ 
fcm 터지는 이유도 알아야하고 겸사겸사 feign decoder에서 터진 에러를 로깅도 하면 좋으니까 추가했습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기타(Chores)**
  * 외부 요청 실패 시 로깅을 강화하여 호출 정보(메서드 식별자), 상태 코드, 사유와 응답 본문을 함께 기록하도록 개선했습니다(본문은 길이 제한으로 일부만 저장).
  * 기존의 상태별 오류 처리 동작은 유지되어, 기존과 동일한 오류 유형이 계속 발생합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->