### PR TITLE
651 교시 시간 수정

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
@@ -19,9 +19,9 @@ class AttendanceService {
             LocalTime.of(13, 30) to LocalTime.of(14, 40), // 5교시
             LocalTime.of(14, 30) to LocalTime.of(15, 30), // 6교시
             LocalTime.of(15, 30) to LocalTime.of(16, 30), // 7교시
-            LocalTime.of(16, 40) to LocalTime.of(18, 40), // 8교시
+            LocalTime.of(16, 30) to LocalTime.of(18, 40), // 8교시
             LocalTime.of(18, 40) to LocalTime.of(19, 40), // 9교시
-            LocalTime.of(19, 40) to LocalTime.of(20, 30) // 10교시
+            LocalTime.of(19, 40) to LocalTime.of(20, 31) // 10교시
         )
         val periodNames = listOf(
             "1교시", "2교시", "3교시", "4교시", "5교시",


### PR DESCRIPTION
기존 교시에서 16:30~16:40에 시간으로 신청 시, 교시로 변환되지 않는 오류가 있었습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 8교시 시작 시간을 16:40에서 16:30으로 조정하여 8교시를 10분 연장했습니다.
* 10교시 종료 시간을 20:30에서 20:31로 조정하여 10교시를 1분 연장했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->