### PR TITLE
add :: 급식 수동 refresh API 추가

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/admin/presentation/AdminController.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/admin/presentation/AdminController.kt
@@ -1,6 +1,7 @@
 package dsm.pick2024.domain.admin.presentation
 
 import dsm.pick2024.domain.admin.port.`in`.*
+import dsm.pick2024.domain.meal.port.`in`.RetryMealUseCase
 import dsm.pick2024.domain.admin.presentation.dto.request.AdminLoginRequest
 import dsm.pick2024.domain.admin.presentation.dto.request.AdminPasswordResetRequest
 import dsm.pick2024.domain.admin.presentation.dto.request.AdminSignUpRequest
@@ -31,7 +32,8 @@ class AdminController(
     private val verifySecretKeyUseCase: VerifySecretKeyUseCase,
     private val adminPasswordResetUseCase: AdminPasswordResetUseCase,
     private val adminDeleteUseCase: AdminDeleteUseCase,
-    private val queryMainInfoUseCase: QueryMainInfoUseCase
+    private val queryMainInfoUseCase: QueryMainInfoUseCase,
+    private val retryMealUseCase: RetryMealUseCase
 ) {
     @Operation(summary = "어드민 로그인 API")
     @PostMapping("/login")
@@ -80,4 +82,10 @@ class AdminController(
     @GetMapping("/main")
     fun queryMainInfo(): QueryMainInfoResponse =
         queryMainInfoUseCase.execute()
+
+    @Operation(summary = "이번 달 급식 데이터 수동 재조회 API")
+    @PostMapping("/scheduler/meal/retry")
+    fun retryMealScheduler() {
+        retryMealUseCase.execute()
+    }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/meal/domain/Meal.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/domain/Meal.kt
@@ -9,7 +9,7 @@ import java.util.UUID
 data class Meal(
     val id: UUID = UUID(0, 0),
     val mealDate: LocalDate,
-    val mealType: MealType?,
+    val mealType: MealType,
     val menu: String?,
     val cal: String?
 ) {

--- a/src/main/kotlin/dsm/pick2024/domain/meal/entity/MealJpaEntity.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/entity/MealJpaEntity.kt
@@ -23,8 +23,8 @@ class MealJpaEntity(
     val mealDate: LocalDate,
 
     @Enumerated(value = EnumType.STRING)
-    @Column(nullable = true, columnDefinition = "TEXT")
-    val mealType: MealType?,
+    @Column(nullable = false, columnDefinition = "TEXT")
+    val mealType: MealType,
 
     val menu: String? = null,
 

--- a/src/main/kotlin/dsm/pick2024/domain/meal/entity/MealJpaEntity.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/entity/MealJpaEntity.kt
@@ -8,8 +8,14 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.Table
+import javax.persistence.UniqueConstraint
 
-@Entity(name = "tbl_meal")
+@Entity
+@Table(
+    name = "tbl_meal",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["mealDate", "mealType"])]
+)
 class MealJpaEntity(
     id: UUID?,
 

--- a/src/main/kotlin/dsm/pick2024/domain/meal/persistence/MealPersistenceAdapter.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/persistence/MealPersistenceAdapter.kt
@@ -8,6 +8,7 @@ import dsm.pick2024.domain.meal.persistence.repository.MealRepository
 import dsm.pick2024.domain.meal.port.out.MealPort
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.time.YearMonth
 
 @Component
 class MealPersistenceAdapter(
@@ -25,5 +26,12 @@ class MealPersistenceAdapter(
             .where(QMealJpaEntity.mealJpaEntity.mealDate.eq(date))
             .fetch()
             .map { mealMapper.toDomain(it) }
+    }
+
+    override fun deleteByYearMonth(yearMonth: YearMonth) {
+        mealRepository.deleteAllByMealDateBetween(
+            yearMonth.atDay(1),
+            yearMonth.atEndOfMonth()
+        )
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/meal/persistence/repository/MealRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/persistence/repository/MealRepository.kt
@@ -2,6 +2,9 @@ package dsm.pick2024.domain.meal.persistence.repository
 
 import dsm.pick2024.domain.meal.entity.MealJpaEntity
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 import java.util.UUID
 
-interface MealRepository : JpaRepository<MealJpaEntity, UUID>
+interface MealRepository : JpaRepository<MealJpaEntity, UUID> {
+    fun deleteAllByMealDateBetween(start: LocalDate, end: LocalDate)
+}

--- a/src/main/kotlin/dsm/pick2024/domain/meal/port/in/RetryMealUseCase.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/port/in/RetryMealUseCase.kt
@@ -1,0 +1,5 @@
+package dsm.pick2024.domain.meal.port.`in`
+
+interface RetryMealUseCase {
+    fun execute()
+}

--- a/src/main/kotlin/dsm/pick2024/domain/meal/port/out/DeleteMealPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/port/out/DeleteMealPort.kt
@@ -1,0 +1,7 @@
+package dsm.pick2024.domain.meal.port.out
+
+import java.time.YearMonth
+
+interface DeleteMealPort {
+    fun deleteByYearMonth(yearMonth: YearMonth)
+}

--- a/src/main/kotlin/dsm/pick2024/domain/meal/port/out/MealPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/port/out/MealPort.kt
@@ -2,4 +2,5 @@ package dsm.pick2024.domain.meal.port.out
 
 interface MealPort :
     SaveMealPort,
-    QueryMealPort
+    QueryMealPort,
+    DeleteMealPort

--- a/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
@@ -6,43 +6,39 @@ import dsm.pick2024.domain.meal.port.out.MealPort
 import dsm.pick2024.global.common.TimeUtils
 import dsm.pick2024.infrastructure.feign.neis.NeisMealFeignClientService
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.support.TransactionTemplate
 import java.time.YearMonth
 
 @Service
 class RetryMealService(
     private val mealPort: MealPort,
-    private val neisMealFeignClientService: NeisMealFeignClientService
+    private val neisMealFeignClientService: NeisMealFeignClientService,
+    transactionManager: PlatformTransactionManager
 ) : RetryMealUseCase {
 
-    @Transactional
+    private val transactionTemplate = TransactionTemplate(transactionManager)
+
     override fun execute() {
         val currentMonth = YearMonth.from(TimeUtils.nowLocalDate())
 
-        mealPort.deleteByYearMonth(currentMonth)
-
-        val mealForSave = neisMealFeignClientService.getNeisInfoToEntityByYearMonth(currentMonth)
-
-        mealForSave
+        // 트랜잭션 외부에서 Feign 호출
+        val mealsToSave = neisMealFeignClientService.getNeisInfoToEntityByYearMonth(currentMonth)
             .groupBy { it.mealDate }
-            .forEach { (date, mealInfos) ->
-                val mealMap = mealInfos.groupBy { it.mealType }
-
-                mealMap.forEach { (mealType, mealsOfType) ->
-                    val menu = mealsOfType.map { it.menu }.filterNotNull().distinct().joinToString("||")
-                    val cal = mealsOfType.map { it.cal }.get(0)
-
-                    if (menu.isNotEmpty()) {
-                        mealPort.save(
-                            Meal(
-                                mealDate = date,
-                                mealType = mealType,
-                                menu = menu,
-                                cal = cal
-                            )
-                        )
+            .flatMap { (date, mealInfos) ->
+                mealInfos.groupBy { it.mealType }
+                    .mapNotNull { (mealType, mealsOfType) ->
+                        val menu = mealsOfType.mapNotNull { it.menu }.distinct().joinToString("||")
+                        val cal = mealsOfType.map { it.cal }.get(0)
+                        if (menu.isNotEmpty()) Meal(mealDate = date, mealType = mealType, menu = menu, cal = cal)
+                        else null
                     }
-                }
             }
+
+        // Feign 응답 수신 후 트랜잭션 시작 → 삭제 + 저장
+        transactionTemplate.execute {
+            mealPort.deleteByYearMonth(currentMonth)
+            mealsToSave.forEach { mealPort.save(it) }
+        }
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
@@ -30,8 +30,11 @@ class RetryMealService(
                     .mapNotNull { (mealType, mealsOfType) ->
                         val menu = mealsOfType.mapNotNull { it.menu }.distinct().joinToString("||")
                         val cal = mealsOfType.map { it.cal }.get(0)
-                        if (menu.isNotEmpty()) Meal(mealDate = date, mealType = mealType, menu = menu, cal = cal)
-                        else null
+                        if (menu.isNotEmpty()) {
+                            Meal(mealDate = date, mealType = mealType, menu = menu, cal = cal)
+                        } else {
+                            null
+                        }
                     }
             }
 

--- a/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
@@ -19,6 +19,7 @@ class RetryMealService(
 
     private val transactionTemplate = TransactionTemplate(transactionManager)
 
+    @Synchronized
     override fun execute() {
         val currentMonth = YearMonth.from(TimeUtils.nowLocalDate())
 

--- a/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/service/RetryMealService.kt
@@ -1,0 +1,48 @@
+package dsm.pick2024.domain.meal.service
+
+import dsm.pick2024.domain.meal.domain.Meal
+import dsm.pick2024.domain.meal.port.`in`.RetryMealUseCase
+import dsm.pick2024.domain.meal.port.out.MealPort
+import dsm.pick2024.global.common.TimeUtils
+import dsm.pick2024.infrastructure.feign.neis.NeisMealFeignClientService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.YearMonth
+
+@Service
+class RetryMealService(
+    private val mealPort: MealPort,
+    private val neisMealFeignClientService: NeisMealFeignClientService
+) : RetryMealUseCase {
+
+    @Transactional
+    override fun execute() {
+        val currentMonth = YearMonth.from(TimeUtils.nowLocalDate())
+
+        mealPort.deleteByYearMonth(currentMonth)
+
+        val mealForSave = neisMealFeignClientService.getNeisInfoToEntityByYearMonth(currentMonth)
+
+        mealForSave
+            .groupBy { it.mealDate }
+            .forEach { (date, mealInfos) ->
+                val mealMap = mealInfos.groupBy { it.mealType }
+
+                mealMap.forEach { (mealType, mealsOfType) ->
+                    val menu = mealsOfType.map { it.menu }.filterNotNull().distinct().joinToString("||")
+                    val cal = mealsOfType.map { it.cal }.get(0)
+
+                    if (menu.isNotEmpty()) {
+                        mealPort.save(
+                            Meal(
+                                mealDate = date,
+                                mealType = mealType,
+                                menu = menu,
+                                cal = cal
+                            )
+                        )
+                    }
+                }
+            }
+    }
+}

--- a/src/main/kotlin/dsm/pick2024/domain/meal/service/SaveMealService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/meal/service/SaveMealService.kt
@@ -82,7 +82,7 @@ class SaveMealService(
 
                 mealMap.forEach { (mealType, mealsOfType) ->
                     val menu = stickMeal(mealsOfType.map { it.menu })
-                    val cal = mealsOfType.map { it.cal }.get(0)//mealsOfType.firstNotNullOfOrNull { it.cal }
+                    val cal = mealsOfType.map { it.cal }.get(0)
                     if (menu.isNotEmpty()) {
                         saveMealPort.save(
                             Meal(

--- a/src/main/kotlin/dsm/pick2024/global/security/path/SecurityPaths.kt
+++ b/src/main/kotlin/dsm/pick2024/global/security/path/SecurityPaths.kt
@@ -69,7 +69,8 @@ object SecurityPaths {
         "/status/saveAll",
         "/schedule/save",
         "/notice/create",
-        "/weekend-meal/application-list"
+        "/weekend-meal/application-list",
+        "/admin/scheduler/meal/retry"
     )
     val SCH_DELETE_ENDPOINTS = arrayOf(
         "/after/**",

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/neis/NeisMealFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/neis/NeisMealFeignClientService.kt
@@ -126,10 +126,10 @@ class NeisMealFeignClientService(
             sb.toString()
         }
 
-    private fun getMealType(mealCode: String): MealType? = when (mealCode) {
+    private fun getMealType(mealCode: String): MealType = when (mealCode) {
         "1" -> MealType.BREAKFAST
         "2" -> MealType.LUNCH
         "3" -> MealType.DINNER
-        else -> null
+        else -> throw IllegalArgumentException("알 수 없는 NEIS 식사 코드입니다: $mealCode")
     }
 }

--- a/src/main/kotlin/dsm/pick2024/infrastructure/feign/neis/NeisMealFeignClientService.kt
+++ b/src/main/kotlin/dsm/pick2024/infrastructure/feign/neis/NeisMealFeignClientService.kt
@@ -10,6 +10,7 @@ import dsm.pick2024.infrastructure.feign.neis.property.NeisFeignClientRequestPro
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 
 @Component
@@ -21,8 +22,15 @@ class NeisMealFeignClientService(
 
     fun getNeisInfoToEntity(): MutableList<Meal> {
         val kstToday = TimeUtils.nowLocalDate()
-        val nextMonth = kstToday.plusMonths(1)
+        val nextMonth = YearMonth.from(kstToday).plusMonths(1)
+        return fetchMealsByYearMonth(nextMonth)
+    }
 
+    fun getNeisInfoToEntityByYearMonth(yearMonth: YearMonth): MutableList<Meal> {
+        return fetchMealsByYearMonth(yearMonth)
+    }
+
+    private fun fetchMealsByYearMonth(yearMonth: YearMonth): MutableList<Meal> {
         val neisMealServiceDietInfoString =
             neisFeignClient.getMealServiceDietInfo(
                 key = neisKey,
@@ -31,8 +39,8 @@ class NeisMealFeignClientService(
                 pageSize = NeisFeignClientRequestProperty.PAGE_SIZE,
                 sdSchoolCode = NeisFeignClientRequestProperty.SD_SCHUL_CODE,
                 atptCode = NeisFeignClientRequestProperty.ATPT_OFCDC_CODE,
-                startedYmd = changeDateTimeFormat(nextMonth.withDayOfMonth(1).toString()),
-                endedYmd = changeDateTimeFormat(nextMonth.withDayOfMonth(nextMonth.lengthOfMonth()).toString())
+                startedYmd = changeDateTimeFormat(yearMonth.atDay(1).toString()),
+                endedYmd = changeDateTimeFormat(yearMonth.atEndOfMonth().toString())
             )
 
         val mealJson =

--- a/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
+++ b/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tbl_meal`
+    ADD UNIQUE KEY `uk_meal_date_type` (`mealDate`, `mealType`);

--- a/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
+++ b/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
@@ -1,2 +1,5 @@
 ALTER TABLE `tbl_meal`
+    MODIFY COLUMN `mealType` TEXT NOT NULL;
+
+ALTER TABLE `tbl_meal`
     ADD UNIQUE KEY `uk_meal_date_type` (`mealDate`, `mealType`);


### PR DESCRIPTION
급식을 수동으로 refeash하는 API를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 관리자가 즉시 특정 월의 급식 데이터를 재수집·갱신할 수 있는 재시도 API(POST /admin/scheduler/meal/retry) 추가
  * 연월 단위로 한 달치 급식 데이터를 일괄 삭제하고 재저장하는 월별 삭제·갱신 기능 추가
* **통합 및 외부 연동**
  * 외부 급식 API의 월별 조회 엔드포인트와 관련 조회 흐름 확장
* **데이터 무결성 / 모델 변경**
  * 식사 데이터의 (mealDate, mealType)에 대한 DB 고유 제약 추가 및 mealType을 비 nullable로 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->