### PR TITLE
feat :: debezium 설정값을 never로 변경

### DIFF
--- a/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumProperties.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumProperties.kt
@@ -16,7 +16,8 @@ data class DebeziumProperties(
         val name: String,
         val connectorClass: String = "io.debezium.connector.mysql.MySqlConnector",
         val tasksMax: Int = 1,
-        val timePrecisionMode: String = "connect"
+        val timePrecisionMode: String = "connect",
+        val snapshotMode: String = "never"
     )
 
     data class DatabaseConfig(
@@ -54,6 +55,7 @@ data class DebeziumProperties(
             "connector.class" to connector.connectorClass,
             "tasks.max" to connector.tasksMax.toString(),
 
+            "snapshot.mode" to connector.snapshotMode,
             "time.precision.mode" to connector.timePrecisionMode,
 
             "database.server.timezone" to database.serverTimeZone,

--- a/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
+++ b/src/main/resources/db/migration/V4_add_unique_constraint_to_meal_date_and_type.sql
@@ -1,5 +1,11 @@
-ALTER TABLE `tbl_meal`
-    MODIFY COLUMN `mealType` TEXT NOT NULL;
+DELETE t1 FROM tbl_meal t1
+                   INNER JOIN tbl_meal t2
+WHERE t1.meal_date = t2.meal_date
+  AND t1.meal_type = t2.meal_type
+  AND t1.id > t2.id;
 
 ALTER TABLE `tbl_meal`
-    ADD UNIQUE KEY `uk_meal_date_type` (`mealDate`, `mealType`);
+    MODIFY COLUMN `meal_type` varchar(20) NOT NULL;
+
+ALTER TABLE `tbl_meal`
+    ADD UNIQUE KEY `uk_meal_date_type` (`meal_date`, `meal_type`);


### PR DESCRIPTION
 - never (기본값): 재시작해도 기존 offset에서 이어서 읽음, 스냅샷 안 함
  - 첫 배포 시 초기 스냅샷이 필요하면 initial로 설정 후 한 번만 실행하고, 이후
  never로 변경                                                                        
  이렇게 하면 재시작할 때마다 snapshot.mode가 명시적으로 never로 포함되어          
  덮어써지지 않습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Debezium 스냅샷 모드 설정 옵션 추가 (기본값: "never")
  * 식사 데이터의 날짜 및 유형 조합에 대한 고유성 제약 추가

* **버그 수정**
  * 식사 테이블의 중복 데이터 정리 및 스키마 정렬

<!-- end of auto-generated comment: release notes by coderabbit.ai -->