### PR TITLE
feat :: fix: 외출 기록 조회 학생 목록 출처 tbl_status → tbl_user 변경 및 saveAll 중복

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/applicationstory/service/QueryAllUserApplicationStoryService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/applicationstory/service/QueryAllUserApplicationStoryService.kt
@@ -4,34 +4,33 @@ import dsm.pick2024.domain.applicationstory.enums.Type
 import dsm.pick2024.domain.applicationstory.port.`in`.QueryAllUserApplicationStoryUseCase
 import dsm.pick2024.domain.applicationstory.port.out.QueryAllApplicationStoryPort
 import dsm.pick2024.domain.applicationstory.presentation.dto.response.QueryUserClassResponse
-import dsm.pick2024.domain.status.port.out.QueryStatusPort
-import dsm.pick2024.domain.user.exception.UserNotFoundException
+import dsm.pick2024.domain.user.port.out.QueryUserPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class QueryAllUserApplicationStoryService(
-    private val queryStatusPort: QueryStatusPort,
+    private val queryUserPort: QueryUserPort,
     private val queryAllApplicationStoryPort: QueryAllApplicationStoryPort
 ) : QueryAllUserApplicationStoryUseCase {
     @Transactional(readOnly = true)
     override fun queryAllUSerApplicationStory(): List<QueryUserClassResponse> {
-        return queryStatusPort.findAll()
-            .map { student ->
+        return queryUserPort.findAll()
+            .map { user ->
                 val applicationStory =
-                    queryAllApplicationStoryPort.findAllByUserId(student.userId) ?: throw UserNotFoundException
-                val applicationCnt = applicationStory.count { it.type == Type.APPLICATION } ?: 0
-                val earlyReturnCnt = applicationStory.count { it.type == Type.EARLY_RETURN } ?: 0
+                    queryAllApplicationStoryPort.findAllByUserId(user.id) ?: emptyList()
+                val applicationCnt = applicationStory.count { it.type == Type.APPLICATION }
+                val earlyReturnCnt = applicationStory.count { it.type == Type.EARLY_RETURN }
 
                 QueryUserClassResponse(
-                    id = student.userId,
-                    userName = student.userName,
-                    grade = student.grade,
-                    classNum = student.classNum,
-                    num = student.num,
+                    id = user.id,
+                    userName = user.name,
+                    grade = user.grade,
+                    classNum = user.classNum,
+                    num = user.num,
                     applicationCnt = applicationCnt,
                     earlyReturnCnt = earlyReturnCnt
                 )
-            }.distinctBy { it.id }.sortedWith(compareBy({ it.grade }, { it.classNum }, { it.num }))
+            }.sortedWith(compareBy({ it.grade }, { it.classNum }, { it.num }))
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/applicationstory/service/QueryClassUserService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/applicationstory/service/QueryClassUserService.kt
@@ -4,40 +4,36 @@ import dsm.pick2024.domain.applicationstory.enums.Type
 import dsm.pick2024.domain.applicationstory.port.`in`.QueryClassUserUseCase
 import dsm.pick2024.domain.applicationstory.port.out.QueryAllApplicationStoryPort
 import dsm.pick2024.domain.applicationstory.presentation.dto.response.QueryUserClassResponse
-import dsm.pick2024.domain.status.port.out.QueryStatusPort
-import dsm.pick2024.domain.user.exception.UserNotFoundException
+import dsm.pick2024.domain.user.port.out.QueryUserPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class QueryClassUserService(
     private val queryAllApplicationStoryPort: QueryAllApplicationStoryPort,
-    private val queryStatusPort: QueryStatusPort
+    private val queryUserPort: QueryUserPort
 ) : QueryClassUserUseCase {
     @Transactional(readOnly = true)
     override fun queryClassUser(
         grade: Int,
         classNum: Int
     ): List<QueryUserClassResponse> {
-        val students = queryStatusPort.findByGradeAndClassNum(grade, classNum)
+        return queryUserPort.findByGradeAndClassNum(grade, classNum)
+            .map { user ->
+                val applicationStory =
+                    queryAllApplicationStoryPort.findAllByUserId(user.id) ?: emptyList()
+                val applicationCnt = applicationStory.count { it.type == Type.APPLICATION }
+                val earlyReturnCnt = applicationStory.count { it.type == Type.EARLY_RETURN }
 
-        return students.map { student ->
-            val applicationStory =
-                queryAllApplicationStoryPort.findAllByUserId(student.userId) ?: throw UserNotFoundException
-            val applicationCnt = applicationStory.count { it.type == Type.APPLICATION } ?: 0
-            val earlyReturnCnt = applicationStory.count { it.type == Type.EARLY_RETURN } ?: 0
-
-            QueryUserClassResponse(
-                id = student.userId,
-                userName = student.userName,
-                grade = student.grade,
-                classNum = student.classNum,
-                num = student.num,
-                applicationCnt = applicationCnt,
-                earlyReturnCnt = earlyReturnCnt
-            )
-        }.distinctBy { it.id }.sortedWith(
-            compareBy { it.num }
-        )
+                QueryUserClassResponse(
+                    id = user.id,
+                    userName = user.name,
+                    grade = user.grade,
+                    classNum = user.classNum,
+                    num = user.num,
+                    applicationCnt = applicationCnt,
+                    earlyReturnCnt = earlyReturnCnt
+                )
+            }.sortedWith(compareBy { it.num })
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/status/persistence/StatusPersistenceAdapterPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/persistence/StatusPersistenceAdapterPort.kt
@@ -43,4 +43,10 @@ class StatusPersistenceAdapterPort(
     }
 
     override fun findAll(): List<Status> = statusRepository.findAll().map { statusMapper.toDomain(it) }
+
+    override fun deleteByUserIds(userIds: List<UUID>) {
+        if (userIds.isNotEmpty()) {
+            statusRepository.deleteByUserIdIn(userIds)
+        }
+    }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/status/persistence/repository/StatusRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/persistence/repository/StatusRepository.kt
@@ -12,4 +12,6 @@ interface StatusRepository : Repository<StatusJpaEntity, UUID> {
     fun save(entity: StatusJpaEntity)
 
     fun findAll(): List<StatusJpaEntity>
+
+    fun deleteByUserIdIn(userIds: Collection<UUID>)
 }

--- a/src/main/kotlin/dsm/pick2024/domain/status/port/out/SaveStatusPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/port/out/SaveStatusPort.kt
@@ -1,9 +1,12 @@
 package dsm.pick2024.domain.status.port.out
 
 import dsm.pick2024.domain.status.domain.Status
+import java.util.UUID
 
 interface SaveStatusPort {
     fun save(status: Status)
 
     fun saveAll(statuses: MutableList<Status>)
+
+    fun deleteByUserIds(userIds: List<UUID>)
 }

--- a/src/main/kotlin/dsm/pick2024/domain/status/service/SaveAllStatusUserService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/service/SaveAllStatusUserService.kt
@@ -3,30 +3,46 @@ package dsm.pick2024.domain.status.service
 import dsm.pick2024.domain.status.domain.Status
 import dsm.pick2024.domain.status.entity.enum.StatusType
 import dsm.pick2024.domain.status.port.`in`.SaveAllStatusUserUseCase
+import dsm.pick2024.domain.status.port.out.QueryStatusPort
 import dsm.pick2024.domain.status.port.out.SaveStatusPort
-import dsm.pick2024.infrastructure.feign.xquare.client.XquareFeignClient
+import dsm.pick2024.domain.user.port.out.QueryUserPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class SaveAllStatusUserService(
     private val saveStatusPort: SaveStatusPort,
-    private val xquareFeignClient: XquareFeignClient
+    private val queryStatusPort: QueryStatusPort,
+    private val queryUserPort: QueryUserPort
 ) : SaveAllStatusUserUseCase {
     @Transactional
     override fun saveAll(key: String) {
-        val xquareUserInfo = xquareFeignClient.userAll(key)
-        val statusEntities =
-            xquareUserInfo.map { user ->
-                Status(
-                    userId = user.id,
-                    userName = user.name,
-                    grade = user.grade,
-                    classNum = user.classNum,
-                    num = user.num,
-                    status = StatusType.ATTENDANCE
-                )
-            }.toMutableList()
-        saveStatusPort.saveAll(statusEntities)
+        val allUsers = queryUserPort.findAll()
+
+        // 기존 상태 보존 (중복 행이 있을 경우 외출/조기귀가 상태 우선)
+        val currentStatusByUserId = queryStatusPort.findAll()
+            .groupBy { it.userId }
+            .mapValues { (_, statuses) ->
+                statuses.firstOrNull { it.status != StatusType.ATTENDANCE }?.status
+                    ?: StatusType.ATTENDANCE
+            }
+
+        // 기존 행 전체 삭제 (중복 정리 + 탈퇴 학생 제거)
+        val allExistingUserIds = currentStatusByUserId.keys.toList()
+        saveStatusPort.deleteByUserIds(allExistingUserIds)
+
+        // pick DB 전체 학생 기준으로 재삽입 (상태 복원)
+        val toSave = allUsers.map { user ->
+            Status(
+                userId = user.id,
+                userName = user.name,
+                grade = user.grade,
+                classNum = user.classNum,
+                num = user.num,
+                status = currentStatusByUserId[user.id] ?: StatusType.ATTENDANCE
+            )
+        }.toMutableList()
+
+        saveStatusPort.saveAll(toSave)
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/user/persistence/UserPersistenceAdapter.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/persistence/UserPersistenceAdapter.kt
@@ -46,6 +46,9 @@ class UserPersistenceAdapter(
         return userRepository.findByAccountId(accountId)?.let { userMapper.toDomain(it) }
     }
 
+    override fun findByGradeAndClassNum(grade: Int, classNum: Int): List<User> =
+        userRepository.findAllByGradeAndClassNum(grade, classNum).map { userMapper.toDomain(it) }
+
     override fun deleteById(userId: UUID) {
         userRepository.deleteById(userId)
     }

--- a/src/main/kotlin/dsm/pick2024/domain/user/persistence/repository/UserRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/persistence/repository/UserRepository.kt
@@ -27,4 +27,6 @@ interface UserRepository : Repository<UserJpaEntity, UUID> {
     ): UserJpaEntity?
 
     fun existsByGradeAndClassNumAndNum(grade: Int, classNum: Int, num: Int): Boolean
+
+    fun findAllByGradeAndClassNum(grade: Int, classNum: Int): List<UserJpaEntity>
 }

--- a/src/main/kotlin/dsm/pick2024/domain/user/port/out/QueryUserPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/user/port/out/QueryUserPort.kt
@@ -15,4 +15,6 @@ interface QueryUserPort {
     fun findAll(): List<User>
 
     fun findByUserId(userId: UUID): User?
+
+    fun findByGradeAndClassNum(grade: Int, classNum: Int): List<User>
 }


### PR DESCRIPTION
## 변경 사항

  ### 외출 기록 조회 학생 목록 출처 변경
  - `QueryAllUserApplicationStoryService` — `queryStatusPort.findAll()` →      
  `queryUserPort.findAll()`
  - `QueryClassUserService` — `queryStatusPort.findByGradeAndClassNum()` →     
  `queryUserPort.findByGradeAndClassNum()`
  - `UserRepository`, `QueryUserPort`, `UserPersistenceAdapter` —
  `findByGradeAndClassNum()` 메서드 추가

  ### saveAll() 로직 개선
  - `SaveAllStatusUserService` — 외부 API 제거, pick 자체 `tbl_user` 기반으로  
  변경
  - 기존 행 전체 삭제 후 재삽입 방식 적용 (중복 방지, 현재 출석 상태 보존)     
  - `StatusRepository`, `SaveStatusPort`, `StatusPersistenceAdapterPort` —     
  `deleteByUserIds()` 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 정보 조회 시스템 효율성 개선
  * 상태 정보 관리 및 처리 안정성 강화
  * 애플리케이션 데이터 처리 최적화로 시스템 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->