### PR TITLE
669-snapshotMode 기본값 never 삭제

### DIFF
--- a/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumProperties.kt
+++ b/src/main/kotlin/dsm/pick2024/global/config/debezium/DebeziumProperties.kt
@@ -17,7 +17,7 @@ data class DebeziumProperties(
         val connectorClass: String = "io.debezium.connector.mysql.MySqlConnector",
         val tasksMax: Int = 1,
         val timePrecisionMode: String = "connect",
-        val snapshotMode: String = "never"
+        val snapshotMode: String
     )
 
     data class DatabaseConfig(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 변경**
  * 스냅샷 모드 설정이 필수 항목으로 변경되었습니다. 기존의 기본값이 제거되었으므로 외부 설정을 통해 명시적으로 스냅샷 모드 값을 제공해야 합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->