### PR TITLE
fix :: 외출 출석 오처리 수정 및 NonUniqueResultException 버그 수정

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
@@ -168,17 +168,12 @@ class AttendanceService {
     }
 
     private fun getMatchPeriods(startTime: LocalTime, endTime: LocalTime): Pair<String, String> {
-        val startIndex = periods.indexOfFirst { (start, endAt) ->
-            startTime in start..endAt
-        }.takeIf { it != -1 }
-            ?: if (startTime < periods.first().first) 0 else throw InvalidPeriodException
+        val matchedIndices = periods.withIndex()
+            .filter { (_, period) -> period.first.isBefore(endTime) && period.second.isAfter(startTime) }
+            .map { it.index }
 
-        val endIndex = periods.indexOfFirst { (start, endAt) ->
-            endTime in start..endAt
-        }
+        if (matchedIndices.isEmpty()) throw InvalidPeriodException
 
-        if (endIndex == -1) throw InvalidPeriodException
-
-        return periodNames[startIndex] to periodNames[endIndex]
+        return periodNames[matchedIndices.first()] to periodNames[matchedIndices.last()]
     }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
@@ -46,7 +46,7 @@ class AttendanceService {
             ApplicationType.TIME -> {
                 val startTime = LocalTime.parse(start)
                 val endTime = LocalTime.parse(end)
-                if (startTime > endTime ||
+                if (!startTime.isBefore(endTime) ||
                     endTime > LocalTime.of(20, 30) ||
                     startTime < LocalTime.of(8, 30)
                 ) {

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/domain/service/AttendanceService.kt
@@ -17,7 +17,7 @@ class AttendanceService {
             LocalTime.of(10, 40) to LocalTime.of(11, 40), // 3교시
             LocalTime.of(11, 40) to LocalTime.of(13, 30), // 4교시
             LocalTime.of(13, 30) to LocalTime.of(14, 40), // 5교시
-            LocalTime.of(14, 30) to LocalTime.of(15, 30), // 6교시
+            LocalTime.of(14, 40) to LocalTime.of(15, 30), // 6교시
             LocalTime.of(15, 30) to LocalTime.of(16, 30), // 7교시
             LocalTime.of(16, 30) to LocalTime.of(18, 40), // 8교시
             LocalTime.of(18, 40) to LocalTime.of(19, 40), // 9교시

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/AttendancePersistenceAdapter.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/AttendancePersistenceAdapter.kt
@@ -24,7 +24,7 @@ class AttendancePersistenceAdapter(
     }
 
     override fun findByUserId(userId: UUID) =
-        attendanceJpaRepository.findByUserId(userId).let { attendanceMapper.toDomain(it) }
+        attendanceJpaRepository.findFirstByUserId(userId)?.let { attendanceMapper.toDomain(it) }
 
     override fun findAll() = attendanceJpaRepository.findAll().map { attendanceMapper.toDomain(it) }
 

--- a/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/persistence/repository/AttendanceRepository.kt
@@ -9,7 +9,7 @@ interface AttendanceRepository : Repository<AttendanceJpaEntity, UUID> {
 
     fun saveAll(entity: Iterable<AttendanceJpaEntity>)
 
-    fun findByUserId(userId: UUID): AttendanceJpaEntity
+    fun findFirstByUserId(userId: UUID): AttendanceJpaEntity?
 
     fun findAll(): List<AttendanceJpaEntity>
 

--- a/src/main/kotlin/dsm/pick2024/domain/status/persistence/StatusPersistenceAdapterPort.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/persistence/StatusPersistenceAdapterPort.kt
@@ -35,7 +35,7 @@ class StatusPersistenceAdapterPort(
     }
 
     override fun findStatusByUserId(id: UUID): Status? {
-        return statusRepository.findByUserId(id).let { statusMapper.toDomain(it) }
+        return statusRepository.findFirstByUserId(id)?.let { statusMapper.toDomain(it) }
     }
 
     override fun save(status: Status) {

--- a/src/main/kotlin/dsm/pick2024/domain/status/persistence/repository/StatusRepository.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/persistence/repository/StatusRepository.kt
@@ -7,7 +7,7 @@ import java.util.UUID
 interface StatusRepository : Repository<StatusJpaEntity, UUID> {
     fun saveAll(entity: Iterable<StatusJpaEntity>)
 
-    fun findByUserId(userId: UUID): StatusJpaEntity
+    fun findFirstByUserId(userId: UUID): StatusJpaEntity?
 
     fun save(entity: StatusJpaEntity)
 

--- a/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
+++ b/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
@@ -1,15 +1,5 @@
--- 중복 attendance 행 제거 (user_id 기준, 가장 작은 id 하나만 유지)
-DELETE a1 FROM tbl_attendance a1
-INNER JOIN tbl_attendance a2
-    ON a1.user_id = a2.user_id AND a1.id > a2.id;
-
 ALTER TABLE tbl_attendance
     ADD CONSTRAINT uk_attendance_user_id UNIQUE (user_id);
-
--- 중복 status 행 제거 (user_id 기준, 가장 작은 id 하나만 유지)
-DELETE s1 FROM tbl_status s1
-INNER JOIN tbl_status s2
-    ON s1.user_id = s2.user_id AND s1.id > s2.id;
 
 ALTER TABLE tbl_status
     ADD CONSTRAINT uk_status_user_id UNIQUE (user_id);

--- a/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
+++ b/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
@@ -1,0 +1,15 @@
+-- 중복 attendance 행 제거 (user_id 기준, 가장 작은 id 하나만 유지)
+DELETE a1 FROM tbl_attendance a1
+INNER JOIN tbl_attendance a2
+    ON a1.user_id = a2.user_id AND a1.id > a2.id;
+
+ALTER TABLE tbl_attendance
+    ADD CONSTRAINT uk_attendance_user_id UNIQUE (user_id);
+
+-- 중복 status 행 제거 (user_id 기준, 가장 작은 id 하나만 유지)
+DELETE s1 FROM tbl_status s1
+INNER JOIN tbl_status s2
+    ON s1.user_id = s2.user_id AND s1.id > s2.id;
+
+ALTER TABLE tbl_status
+    ADD CONSTRAINT uk_status_user_id UNIQUE (user_id);


### PR DESCRIPTION
## Summary

- 5교시~6교시 시간 겹침으로 인한 외출 출석 오처리 수정
- `tbl_attendance`, `tbl_status` 중복 행으로 인한 `NonUniqueResultException` 수정

---

## [1] 5교시~6교시 시간 겹침 버그

### 문제 원인

`AttendanceService`의 교시 시간 정의에서 **5교시 종료 시간(14:40)과 6교시 시작 시간(14:30)이 10분 겹치는 버그**가 있었습니다.

```kotlin
// 수정 전
LocalTime.of(13, 30) to LocalTime.of(14, 40), // 5교시
LocalTime.of(14, 30) to LocalTime.of(15, 30), // 6교시  ← 14:30~14:40 겹침
```

`ApplicationType.TIME` 기반 외출 신청 승인 시 아래 필터가 사용됩니다.

```kotlin
periods.filter { it.first.isBefore(endTime) && it.second.isAfter(startTime) }
```

예를 들어 **14:30~14:35** 외출 신청 시 5교시와 6교시가 모두 매칭되어 **6교시 출석까지 GO_OUT으로 잘못 변경**되는 문제가 발생했습니다.

### 수정 내용

```kotlin
// 수정 후
LocalTime.of(13, 30) to LocalTime.of(14, 40), // 5교시
LocalTime.of(14, 40) to LocalTime.of(15, 30), // 6교시  ← 14:40으로 정정
```

또한 `getMatchPeriods`의 경계 시각 판단 로직을 반열린 구간으로 통일하여 `translateApplication`과 `updateAttendanceToApplication`의 결과가 일치하도록 수정했습니다.

---

## [2] NonUniqueResultException 버그

### 문제 원인

```
org.springframework.dao.IncorrectResultSizeDataAccessException:
query did not return a unique result: 2
```

`tbl_attendance`, `tbl_status` 테이블에 `user_id` UNIQUE 제약이 없어 중복 행이 존재하는 경우, Spring Data JPA의 `findByUserId` 단건 조회(`getSingleResult()`)가 예외를 던집니다.

`tbl_status`의 중복 행 문제는 `SaveAllStatusUserService`의 주석에서 이미 인지되고 있었으나 단건 조회 쿼리는 수정되지 않은 상태였습니다.

### 수정 내용

| 변경 | 내용 |
|---|---|
| `AttendanceRepository` | `findByUserId` → `findFirstByUserId` (`LIMIT 1` 적용) |
| `StatusRepository` | `findByUserId` → `findFirstByUserId` (`LIMIT 1` 적용) |
| 어댑터 2곳 | `?.let` null-safe 처리 |
| Flyway 마이그레이션 | 기존 중복 행 제거 + `UNIQUE(user_id)` 제약 추가 |

---

## Test plan

- [ ] TIME 타입 5교시 범위 외출 승인 시 6교시(period6)가 GO_OUT으로 바뀌지 않는지 확인
- [ ] TIME 타입 6교시 범위 외출 승인 시 period6만 GO_OUT으로 변경되는지 확인
- [ ] PERIOD 타입 외출 신청은 영향 없음 확인
- [ ] 외출/조기귀가 승인 시 출석 업데이트 정상 동작 확인
- [ ] `/status/change` 정상 동작 확인
- [ ] 마이그레이션 실행 후 `tbl_attendance`, `tbl_status` 중복 행 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)