### PR TITLE
fix :: PICNIC 상태 등록 시 자동 상태 복구 불가 버그 수정

### DIFF
--- a/src/main/kotlin/dsm/pick2024/domain/attendance/service/ResetAttendanceService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/attendance/service/ResetAttendanceService.kt
@@ -35,7 +35,7 @@ class ResetAttendanceService(
 
     private fun getStatus(currentStatus: AttendanceStatus) =
         when (currentStatus) {
-            AttendanceStatus.DROPOUT, AttendanceStatus.PICNIC, AttendanceStatus.EMPLOYMENT -> currentStatus
+            AttendanceStatus.DROPOUT, AttendanceStatus.EMPLOYMENT -> currentStatus
             else -> AttendanceStatus.ATTENDANCE
         }
 }

--- a/src/main/kotlin/dsm/pick2024/domain/status/service/ResetStatusService.kt
+++ b/src/main/kotlin/dsm/pick2024/domain/status/service/ResetStatusService.kt
@@ -14,7 +14,7 @@ class ResetStatusService(
     private val saveStatusPort: SaveStatusPort
 ) : ResetStatusUseCase {
 
-    @Transactional(readOnly = true)
+    @Transactional
     override fun reset() {
         val allStudent = queryStatusPort.findAll()
         val update = mutableListOf<Status>()


### PR DESCRIPTION
## 문제 원인

PICNIC(현장체험학습)으로 상태 변경 후 매일 21:00에 실행되는 리셋 스케줄러가 동작하지 않는 버그 두 가지가 겹쳐 있었습니다.

---

### Bug 1: `ResetStatusService` — `@Transactional(readOnly = true)` 로 인한 리셋 불가

```kotlin
// 수정 전
@Transactional(readOnly = true)
override fun reset() {
    // ...
    saveStatusPort.saveAll(update)  // readOnly = true → flush 안 됨 → DB 미반영
}

// 수정 후
@Transactional
override fun reset() {
```

`readOnly = true`로 설정 시 JPA의 FlushMode가 MANUAL로 강제되어 `saveAll()` 호출이 있어도 실제 DB에 커밋되지 않았습니다. PICNIC뿐 아니라 **모든 상태 리셋이 동작하지 않는** 근본 원인이었습니다.

---

### Bug 2: `ResetAttendanceService` — PICNIC 출석 상태를 영구 보존 처리

```kotlin
// 수정 전
when (currentStatus) {
    AttendanceStatus.DROPOUT, AttendanceStatus.PICNIC, AttendanceStatus.EMPLOYMENT -> currentStatus
    else -> AttendanceStatus.ATTENDANCE
}

// 수정 후
when (currentStatus) {
    AttendanceStatus.DROPOUT, AttendanceStatus.EMPLOYMENT -> currentStatus
    else -> AttendanceStatus.ATTENDANCE
}
```

퇴학(DROPOUT)·취업(EMPLOYMENT)은 영속성 유지가 맞지만, 현장체험학습(PICNIC)은 하루짜리 상태이므로 다음날 ATTENDANCE로 돌아와야 합니다.

---

## 영향 범위

- `ScheduleService.resetTable()` (매일 21:00 실행) 내 `resetStatusUseCase.reset()` + `resetAttendanceUseCase.resetAttendance()` 정상화
- PICNIC 상태 학생이 다음날 자동으로 ATTENDANCE로 복구됨

## Test plan

- [ ] PICNIC으로 상태 변경 후 `reset()` 호출 시 Status가 ATTENDANCE로 변경되는지 확인
- [ ] PICNIC 상태의 출석(period6~10)이 리셋 후 ATTENDANCE로 돌아오는지 확인
- [ ] DROPOUT, EMPLOYMENT 상태는 리셋 후에도 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)