### PR TITLE
feat: Micrometer Prometheus 메트릭 수집 설정 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,9 @@ dependencies {
     implementation(Dependencies.FLYWAY)
 
     implementation(Dependencies.FLYWAY_MYSQL)
+
+    implementation(Dependencies.ACTUATOR)
+    implementation(Dependencies.MICROMETER_PROMETHEUS)
 }
 
 tasks.withType<KotlinCompile> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -56,4 +56,7 @@ object Dependencies {
     const val FLYWAY = "org.flywaydb:flyway-core"
     const val FLYWAY_MYSQL = "org.flywaydb:flyway-mysql"
 
+    const val ACTUATOR = "org.springframework.boot:spring-boot-starter-actuator"
+    const val MICROMETER_PROMETHEUS = "io.micrometer:micrometer-registry-prometheus"
+
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,6 +72,18 @@ auth:
         header: ${JWT_HEADER}
         prefix: ${JWT_PREFIX}
 
+management:
+    endpoints:
+        web:
+            exposure:
+                include: prometheus,health
+    endpoint:
+        prometheus:
+            enabled: true
+    metrics:
+        tags:
+            application: pick-core
+
 server:
     servlet:
         context-path: /dsm-pick


### PR DESCRIPTION
## Summary
- API별 호출 횟수 및 응답시간 모니터링을 위해 Spring Boot Actuator + Micrometer Prometheus 연동 추가
- `build.gradle.kts` 및 `Dependencies.kt`에 의존성 추가
- `application.yaml`에 `/actuator/prometheus`, `/actuator/health` 엔드포인트 노출 설정 추가

## 변경 파일
- `buildSrc/src/main/kotlin/Dependencies.kt` — ACTUATOR, MICROMETER_PROMETHEUS 상수 추가
- `build.gradle.kts` — 두 의존성 implementation 추가
- `src/main/resources/application.yaml` — management 엔드포인트 설정 추가

## 확인 방법
배포 후 아래 엔드포인트에서 메트릭 조회 가능
```
GET /dsm-pick/actuator/prometheus
```

## Test plan
- [ ] 빌드 정상 확인
- [ ] `/actuator/prometheus` 엔드포인트 응답 확인
- [ ] `http_server_requests_seconds_count` 메트릭으로 API별 호출 수 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 애플리케이션 모니터링 및 메트릭 수집 기능 추가
  * 헬스 체크 및 프로메테우스 호환 메트릭 엔드포인트 노출

<!-- end of auto-generated comment: release notes by coderabbit.ai -->