### PR TITLE
fix: Flyway missing migration 무시 및 actuator Security 허용

### DIFF
--- a/src/main/kotlin/dsm/pick2024/global/security/path/SecurityPaths.kt
+++ b/src/main/kotlin/dsm/pick2024/global/security/path/SecurityPaths.kt
@@ -2,6 +2,7 @@ package dsm.pick2024.global.security.path
 
 object SecurityPaths {
     val PERMIT_ALL_ENDPOINTS = arrayOf(
+        "/actuator/**",
         "/admin/login",
         "/admin/refresh",
         "/user/login",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -54,6 +54,8 @@ spring:
         enabled: true
         baseline-on-migrate: true
         baseline-version: 1
+        out-of-order: true
+        ignore-missing-migrations: true
         locations:
             - classpath:db/migration
 


### PR DESCRIPTION
## Summary
- stag 서버 CrashLoopBackOff(59회) 원인인 Flyway 마이그레이션 오류 수정
- `/actuator/**` Security permitAll 추가로 Prometheus 엔드포인트 인증 없이 접근 가능하도록 수정

## 원인
DB에 `202605142007` 마이그레이션이 적용되어 있으나 로컬 코드에 해당 파일이 없어 서버 기동 실패

## 변경 파일
- `application.yaml` — `out-of-order: true`, `ignore-missing-migrations: true` 추가
- `SecurityPaths.kt` — `/actuator/**` permitAll 추가

## Test plan
- [ ] stag 서버 CrashLoopBackOff 해소 확인
- [ ] `GET /dsm-pick/actuator/prometheus` 200 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)