### PR TITLE
fix :: 운영 Flyway 검증 실패 복구 - 삭제된 dedup 마이그레이션 복원

### DIFF
--- a/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
+++ b/src/main/resources/db/migration/V202606041000__deduplicate_and_add_unique_constraints.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tbl_attendance
+    ADD CONSTRAINT uk_attendance_user_id UNIQUE (user_id);
+
+ALTER TABLE tbl_status
+    ADD CONSTRAINT uk_status_user_id UNIQUE (user_id);


### PR DESCRIPTION
## 문제
운영 배포 시 `FlywayValidateException: Migrations have failed validation` 으로 신규 파드가 crash-loop.

운영 `flyway_schema_history` 는 아래 3건을 기대함:
| rank | version | type | checksum |
|---|---|---|---|
| 1 | 1 | BASELINE | (baseline) |
| 2 | 202605142000 | SQL | 1874833870 |
| 3 | 202606041000 | SQL | **634640209** |

그러나 `main` 브랜치에는 **`V202606041000__deduplicate_and_add_unique_constraints.sql` 파일이 삭제**되어 있어 rank3가 누락 → 검증 실패.

## 변경
- 삭제된 dedup 마이그레이션 파일 복원 (`origin/develop` 기준)
- 복원 파일의 Flyway CRC32 = **634640209** 로 운영 rank3와 **정확히 일치** 검증 완료
- `V202605142000__Drop_User.sql`(1874833870)은 이미 일치, `V1__baseline.sql`은 baseline-version(1) 이하라 검증에서 무시됨

## 영향
- 운영 DB 무변경 (파일을 이력에 맞추기만 함)
- 머지 후 배포하면 validate 통과 → 정상 부팅

🤖 Generated with [Claude Code](https://claude.com/claude-code)